### PR TITLE
Improve publication section style

### DIFF
--- a/assets/themes/twitter/css/publications.css
+++ b/assets/themes/twitter/css/publications.css
@@ -63,3 +63,35 @@
   opacity: 1;
   max-height: 1000px;
 }
+
+.pub-entry {
+  font-size: 1.1em;
+  line-height: 1.6;
+  margin-bottom: 15px;
+  font-family: 'Roboto', sans-serif;
+}
+
+.pub-title {
+  font-size: 1.25em;
+  font-weight: bold;
+}
+
+.pub-icons {
+  border-top: 1px solid #ccc;
+  padding-top: 8px;
+  margin-top: 8px;
+  display: flex;
+  gap: 10px;
+}
+
+.pub-action {
+  border: 1px dashed #888;
+  border-radius: 4px;
+  padding: 2px 8px;
+}
+
+.pub-abstract,
+.pub-bibtex {
+  border-left: 4px solid #999;
+}
+

--- a/pubs.md
+++ b/pubs.md
@@ -34,8 +34,8 @@ You can also find my articles on my
 <ol>
 {% for pub in publications %}
   {% if pub.Year == year %}
-    <li>
-      {{ pub.title }}<br>
+    <li class="pub-entry">
+      <span class="pub-title">{{ pub.title }}</span><br>
       <span class="pub-authors">{{ pub.Authors }}</span><br>
       <em>{% if pub.Book %}{{ pub.Book }}{% elsif pub.Journal %}{{ pub.Journal }}{% elsif pub.Conference %}{{ pub.Conference }}{% elsif pub.Publisher %}{{ pub.Publisher }}{% endif %}</em>
       <div class="pub-icons">
@@ -91,8 +91,8 @@ You can also find my articles on my
       <ol>
       {% for p in pubs_of_type %}
         {% if p.year == y %}
-          <li>
-            {{ p.title }}<br>
+          <li class="pub-entry">
+            <span class="pub-title">{{ p.title }}</span><br>
             <span class="pub-authors">{{ p.Authors }}</span><br>
             <em>{{ p.venue }}</em>
             <div class="pub-icons">


### PR DESCRIPTION
## Summary
- style publication entries with larger fonts
- add border styling for abstract, bibtex, and pdf links
- wrap titles in `.pub-title` span

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68755ee5a1ac83318aeb72fe511778ba