### PR TITLE
Improve publication styling

### DIFF
--- a/assets/themes/twitter/css/publications.css
+++ b/assets/themes/twitter/css/publications.css
@@ -19,10 +19,6 @@
   color: #ccc;
 }
 
-.pub-action {
-  font-family: 'Roboto', sans-serif;
-}
-
 .pub-type { display: none; }
 .pub-type.active { display: block; }
 
@@ -31,7 +27,8 @@
   padding: 10px 15px;
   border-radius: 6px;
   margin-top: 8px;
-  line-height: 1.5;
+  line-height: 1.6;
+  font-size: 1.05em;
   display: none;
   opacity: 0;
   max-height: 0;
@@ -52,6 +49,8 @@
   border-radius: 6px;
   font-family: monospace;
   white-space: pre;
+  font-size: 0.95em;
+  line-height: 1.6;
   display: none;
   opacity: 0;
   max-height: 0;
@@ -67,13 +66,17 @@
 .pub-entry {
   font-size: 1.1em;
   line-height: 1.6;
-  margin-bottom: 15px;
+  margin-bottom: 20px;
+  padding-bottom: 15px;
+  border-bottom: 1px solid #e0e0e0;
   font-family: 'Roboto', sans-serif;
+  background-color: #fff;
 }
 
 .pub-title {
-  font-size: 1.25em;
+  font-size: 1.4em;
   font-weight: bold;
+  color: #222;
 }
 
 .pub-icons {
@@ -85,9 +88,20 @@
 }
 
 .pub-action {
-  border: 1px dashed #888;
+  display: inline-block;
+  border: 1px solid #888;
   border-radius: 4px;
   padding: 2px 8px;
+  background-color: #eee;
+  font-size: 0.9em;
+}
+
+.pubyear {
+  font-size: 1.75em;
+  font-weight: 700;
+  margin-top: 30px;
+  margin-bottom: 10px;
+  border-bottom: 2px solid #ddd;
 }
 
 .pub-abstract,


### PR DESCRIPTION
## Summary
- style publication entries with separators and padding
- enlarge title text and year headings
- tweak abstract and bibtex formatting
- style action links as buttons

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68756499f8f48331b3e905fdf29a210e