### PR TITLE
Make research abstracts collapsible

### DIFF
--- a/research.md
+++ b/research.md
@@ -55,6 +55,11 @@ Improving data-intensive, distributed, and parallel science workflows with repro
         }
         .research_abstract {
             font-size: 17px;
+            margin-bottom: 8px;
+        }
+        .research_abstract summary {
+            cursor: pointer;
+            font-weight: bold;
         }
         .research_citation {
             font-size: 15px;
@@ -97,8 +102,8 @@ Improving data-intensive, distributed, and parallel science workflows with repro
             </div>
             <div class="media-body">
                 <h4 class="media-heading">{{r.project}}</h4>
-                <p class="research_abstract">
-                {{r.abstract}}</p>
+                <details class="research_abstract"><summary>Abstract</summary>
+                {{r.abstract}}</details>
                 <p class="research_citation">
                 <strong>{{r.title}}. </strong> {{r.authors}}  <strong><i>, {{r.publication}}</i></strong>, {{r.year}}. 
                 <!-- <a class="btn btn-primary btn-xs btn-research-paper" href="{{r.link}}" role="button">Paper</a> -->

--- a/research_iap.md
+++ b/research_iap.md
@@ -57,6 +57,11 @@ Engage in resource and systems optimization of infrastructure, guided by policy 
         }
         .research_abstract {
             font-size: 17px;
+            margin-bottom: 8px;
+        }
+        .research_abstract summary {
+            cursor: pointer;
+            font-weight: bold;
         }
         .research_citation {
             font-size: 15px;
@@ -99,8 +104,8 @@ Engage in resource and systems optimization of infrastructure, guided by policy 
             </div>
             <div class="media-body">
                 <h4 class="media-heading">{{r.project}}</h4>
-                <p class="research_abstract">
-                {{r.abstract}}</p>
+                <details class="research_abstract"><summary>Abstract</summary>
+                {{r.abstract}}</details>
                 <p class="research_citation">
                 <strong>{{r.title}}. </strong> {{r.authors}}  <strong><i>, {{r.publication}}</i></strong>, {{r.year}}. 
                 <!-- <a class="btn btn-primary btn-xs btn-research-paper" href="{{r.link}}" role="button">Paper</a> -->

--- a/research_xai.md
+++ b/research_xai.md
@@ -57,6 +57,11 @@ Make data, algorithms, and decision-making processes in science workflows explai
         }
         .research_abstract {
             font-size: 17px;
+            margin-bottom: 8px;
+        }
+        .research_abstract summary {
+            cursor: pointer;
+            font-weight: bold;
         }
         .research_citation {
             font-size: 15px;
@@ -99,8 +104,8 @@ Make data, algorithms, and decision-making processes in science workflows explai
             </div>
             <div class="media-body">
                 <h4 class="media-heading">{{r.project}}</h4>
-                <p class="research_abstract">
-                {{r.abstract}}</p>
+                <details class="research_abstract"><summary>Abstract</summary>
+                {{r.abstract}}</details>
                 <p class="research_citation">
                 <strong>{{r.title}}. </strong> {{r.authors}}  <strong><i>, {{r.publication}}</i></strong>, {{r.year}}. 
                 <!-- <a class="btn btn-primary btn-xs btn-research-paper" href="{{r.link}}" role="button">Paper</a> -->


### PR DESCRIPTION
## Summary
- convert research abstracts to collapsible `<details>` blocks
- style summary sections for better visibility

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_687569f83c848331a2bae9cddfeb17b0