### PR TITLE
Fix toggle behavior for publication details

### DIFF
--- a/assets/themes/twitter/css/publications.css
+++ b/assets/themes/twitter/css/publications.css
@@ -88,6 +88,11 @@ body { font-family: 'Roboto', sans-serif; }
   line-height: 1.6;
 }
 
+.pub-abstract {
+  background: #eef2ff;
+  border: 1px solid #ccd;
+}
+
 .pub-bibtex pre {
   margin: 0;
   padding: 8px;

--- a/pubs.md
+++ b/pubs.md
@@ -84,12 +84,12 @@ title: Publications
             </div>
 
             {% if p.Description %}
-            <div id="abs-{{ p.id }}" class="pub-section pub-abstract">
+            <div id="abs-{{ p.id }}" class="pub-section pub-abstract" style="display:none;">
               <p>{{ p.Description }}</p>
             </div>
             {% endif %}
 
-            <div id="bib-{{ p.id }}" class="pub-section pub-bibtex">
+            <div id="bib-{{ p.id }}" class="pub-section pub-bibtex" style="display:none;">
 <pre>@article{ {{ p.id }},
   title     = { {{ p.title }} },
   author    = { {{ p.bibAuthors | default: p.Authors }} },
@@ -142,6 +142,14 @@ document.addEventListener('DOMContentLoaded', ()=> showPubType('all'));
 // toggles single section
 function toggleSection(id) {
   const el = document.getElementById(id);
-  if (el) el.classList.toggle('show');
+  if (!el) return;
+  const isHidden = el.style.display === 'none' || !el.classList.contains('show');
+  if (isHidden) {
+    el.style.display = 'block';
+    el.classList.add('show');
+  } else {
+    el.style.display = 'none';
+    el.classList.remove('show');
+  }
 }
 </script>


### PR DESCRIPTION
## Summary
- hide abstract and BibTeX sections until the buttons are clicked
- give abstracts a light background like BibTeX sections
- update toggle logic to work with inline `display` styles

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_687598ed57dc8331b69f4436fcc7e9be